### PR TITLE
Compatibility with JWT 2.0 library, which fixes a critical security vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## [2.0.0]
+### Changed
+- compatibility with JWT library version 2.0. This library covers an important security vulnerability, 
+see here: https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries. The middleware now requires 
+algorithm parameter to be used when decoding incoming tokens. See spec/authenticate_options_spec.rb for examples. 

--- a/lib/rack/jwt/auth/auth_token.rb
+++ b/lib/rack/jwt/auth/auth_token.rb
@@ -6,7 +6,7 @@ module Rack
 
         # Note: this method is only used by specs
         def self.issue_token(payload, secret)
-          JWT.encode(payload, secret)
+          JWT.encode(payload, secret, 'HS256')
         end
 
         def self.valid?(token, secret, opts = {})

--- a/lib/rack/jwt/auth/authenticate.rb
+++ b/lib/rack/jwt/auth/authenticate.rb
@@ -23,6 +23,10 @@ module Rack
 
           raise 'Secret must be provided' if opts[:secret].nil?
 
+          # @see https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/
+          # @see https://github.com/jwt/ruby-jwt/pull/184
+          raise 'Algorithm must be provided for security reason' if opts[:algorithm].nil?
+
           @secret = opts[:secret]
 
           @authenticated_routes   = compile_paths(opts[:only])

--- a/lib/rack/jwt/auth/version.rb
+++ b/lib/rack/jwt/auth/version.rb
@@ -1,7 +1,7 @@
 module Rack
   module Jwt
     module Auth
-      VERSION = "1.1.1"
+      VERSION = "2.0.0"
     end
   end
 end

--- a/rack-jwt-auth.gemspec
+++ b/rack-jwt-auth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jwt", ">= 1.5.2"
+  spec.add_dependency "jwt", "~> 2.0"
 
   spec.add_development_dependency "bundler",   "~> 1.3"
   spec.add_development_dependency "rake",      "~> 10.3"

--- a/spec/auth_token_spec.rb
+++ b/spec/auth_token_spec.rb
@@ -19,7 +19,7 @@ describe Rack::Jwt::Auth::AuthToken do
 
     it 'checks if the provided token is valid' do
       token   = subject.issue_token(data, secret)
-      payload = subject.valid?(token, secret)
+      payload = subject.valid?(token, secret, { algorithm: 'HS256'})
 
       meta, data = payload
 

--- a/spec/authenticate_options_spec.rb
+++ b/spec/authenticate_options_spec.rb
@@ -3,30 +3,35 @@ require 'spec_helper'
 describe Rack::Jwt::Auth::Authenticate do
   include Rack::Test::Methods
 
-  let(:issuer) { Rack::Jwt::Auth::AuthToken }
+  let(:issuer) {Rack::Jwt::Auth::AuthToken}
 
   context "Except routes" do
 
     let(:app) do
-      main_app = lambda { |env| [200, env, ['Hello']] }
-      Rack::Jwt::Auth::Authenticate.new(main_app, {except: ['/not_authenticated', '/not_authenticated/*'], secret: 'supertestsecret'})
+      main_app = lambda {|env| [200, env, ['Hello']]}
+      Rack::Jwt::Auth::Authenticate.new(main_app,
+                                        {
+                                          except: ['/not_authenticated', '/not_authenticated/*'],
+                                          secret: 'supertestsecret',
+                                          algorithm: 'HS256'
+                                        })
     end
 
     it 'returns 200 ok if the request is for a route that is not authenticated' do
       get('/not_authenticated')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
 
       get('/not_authenticated/other')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
 
       get('/not_authenticated/other/test')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
     end
 
     it 'returns 401 ok if the request is for a route that is authenticated' do
@@ -45,25 +50,27 @@ describe Rack::Jwt::Auth::Authenticate do
   context "Only routes" do
 
     let(:app) do
-      main_app = lambda { |env| [200, env, ['Hello']] }
-      Rack::Jwt::Auth::Authenticate.new(main_app, {only: ['/authenticated', '/authenticated/*'], secret: 'supertestsecret'})
+      main_app = lambda {|env| [200, env, ['Hello']]}
+      Rack::Jwt::Auth::Authenticate.new(main_app, {
+        only: ['/authenticated', '/authenticated/*'], secret: 'supertestsecret', algorithm: 'HS256'
+      })
     end
 
     it 'returns 200 ok if the request is for a route that is not authenticated' do
       get('/not_authenticated')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
 
       get('/not_authenticated/other')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
 
       get('/not_authenticated/other/test')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
     end
 
     it 'returns 401 ok if the request is for a route that is authenticated' do
@@ -82,25 +89,26 @@ describe Rack::Jwt::Auth::Authenticate do
   context "Only with except routes" do
 
     let(:app) do
-      main_app = lambda { |env| [200, env, ['Hello']] }
-      Rack::Jwt::Auth::Authenticate.new(main_app, {only: ['/authenticated', '/authenticated/*'], secret: 'supertestsecret'})
+      main_app = lambda {|env| [200, env, ['Hello']]}
+      Rack::Jwt::Auth::Authenticate.new(main_app, {only: ['/authenticated', '/authenticated/*'], secret: 'supertestsecret',
+                                                   algorithm: 'HS256'})
     end
 
     it 'returns 200 ok if the request is for a route that is not authenticated' do
       get('/not_authenticated')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
 
       get('/not_authenticated/other')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
 
       get('/not_authenticated/other/test')
 
       expect(last_response.status).to eql(200)
-      expect(last_response.body).to   eql('Hello')
+      expect(last_response.body).to eql('Hello')
     end
 
     it 'returns 401 ok if the request is for a route that is authenticated' do
@@ -117,10 +125,10 @@ describe Rack::Jwt::Auth::Authenticate do
   end
 
   context "with options for decode" do
-    let(:secret) { 'supertestsecret' }
+    let(:secret) {'supertestsecret'}
     let(:app) do
-      main_app = lambda { |env| [200, env, ['Hello']] }
-      described_class.new(main_app, { secret: secret, algorithm: 'RS256' })
+      main_app = lambda {|env| [200, env, ['Hello']]}
+      described_class.new(main_app, {secret: secret, algorithm: 'RS256'})
     end
 
     it 'calls AuthToken.valid? with decode options' do
@@ -129,7 +137,7 @@ describe Rack::Jwt::Auth::Authenticate do
       get('/', {}, {'HTTP_AUTHORIZATION' => "Bearer #{token}"})
 
       expect(Rack::Jwt::Auth::AuthToken).to have_received(:valid?)
-          .with(token, secret, { algorithm: 'RS256' })
+                                              .with(token, secret, {algorithm: 'RS256'})
     end
   end
 

--- a/spec/authenticate_options_spec.rb
+++ b/spec/authenticate_options_spec.rb
@@ -9,12 +9,13 @@ describe Rack::Jwt::Auth::Authenticate do
 
     let(:app) do
       main_app = lambda {|env| [200, env, ['Hello']]}
-      Rack::Jwt::Auth::Authenticate.new(main_app,
-                                        {
-                                          except: ['/not_authenticated', '/not_authenticated/*'],
-                                          secret: 'supertestsecret',
-                                          algorithm: 'HS256'
-                                        })
+      Rack::Jwt::Auth::Authenticate.new(
+        main_app,
+        {
+          except: ['/not_authenticated', '/not_authenticated/*'],
+          secret: 'supertestsecret',
+          algorithm: 'HS256'
+        })
     end
 
     it 'returns 200 ok if the request is for a route that is not authenticated' do

--- a/spec/authenticate_spec.rb
+++ b/spec/authenticate_spec.rb
@@ -7,7 +7,7 @@ describe Rack::Jwt::Auth::Authenticate do
 
   let(:app) do
     main_app = lambda { |env| [200, env, ['Hello']] }
-    Rack::Jwt::Auth::Authenticate.new(main_app, {secret: 'supertestsecret'})
+    Rack::Jwt::Auth::Authenticate.new(main_app, {secret: 'supertestsecret', algorithm: 'HS256'})
   end
 
   it 'raises an exception if no secret if provided' do


### PR DESCRIPTION
For description of the vulnerability please see here:

https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/

The rack-jwt-auth now insists on specifying the encryption algorith. 

Thanks